### PR TITLE
Update manifests to presentation 3 in editor screen.

### DIFF
--- a/src/components/Layouts/Manifest.tsx
+++ b/src/components/Layouts/Manifest.tsx
@@ -19,6 +19,7 @@ import {
   cloverViewerOptions,
 } from "lib/vendor/@samvera/clover-iiif";
 import ManifestHeader from "components/UI/Manifest/Header";
+import { convertPresentation2 } from "@iiif/parser/presentation-2";
 
 const Manifest = () => {
   const [manifest, setManifest] = useState<Manifest>();
@@ -31,7 +32,10 @@ const Manifest = () => {
     if (activeManifest)
       fetch(activeManifest)
         .then((response) => response.json())
-        .then((data) => setManifest(data))
+        .then((data) => {
+          const manifestJson = convertPresentation2(data) as Manifest;
+          setManifest(manifestJson);
+        })
         .catch((error) => {
           console.error(`Error fetching ${activeManifest}`, error);
         });


### PR DESCRIPTION
This updates presentation 2 manifest to presentation 3 using the `@iiif/parser` package.

To test:

- Add an Presentation 2 Manifest (https://iiif.harvardartmuseums.org/manifests/object/318197)
- View the Manifest
- Note that the Manifest renders in the Clover viewer
- Note that the Manifest renders table rows for each canvas