### PR TITLE
Get IIIF endpoint baseurl from env.

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -62,11 +62,17 @@ const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     screen: "Collection",
   });
 
+  /**
+   * get the authToken from the useAuthenticator() hook
+   */
   const { user } = useAuthenticator();
-
-  // @ts-ignore
   const authToken = user?.signInUserSession.idToken.jwtToken;
-  const collection = "https://d27rpn9w26s356.cloudfront.net/collection.json";
+
+  /**
+   * get IIIF base url from vite environment variables
+   */
+  const iiifBaseUrl = import.meta.env.VITE_IIIF_BASE_URL;
+  const collection = `${iiifBaseUrl}/collection.json`;
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
This removes the hardcoded URL set for the IIIF endpoint and uses the `VITE_IIIF_BASE_URL` env variable for that value. Users previewing a published collection from the **View in...** options will now see the environment relative published collection.

To verify:

 - Have a `VITE_IIIF_BASE_URL` value in your `.env.local` file at root, ex: https://iiif-maktaba.dc.rdc-staging.library.northwestern.edu
 - Click an option from the **View in...** menu under **Options**
 - Collection should low in relative viewer
 - The IIIF Collection `id` in the `?iiif-content` parameter should have a base url matching the value in your `.env.local`