### PR TITLE
Include delete manifest functionality.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "aws-amplify": "^5.3.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sonner": "^1.2.4"
+        "sonner": "^1.2.4",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
@@ -26,6 +27,7 @@
         "@types/node": "^20.8.8",
         "@types/react": "^18.2.32",
         "@types/react-dom": "^18.2.14",
+        "@types/uuid": "^9.0.8",
         "@vitejs/plugin-react-refresh": "^1.3.6",
         "@vitest/ui": "^0.34.6",
         "jsdom": "^22.1.0",
@@ -15730,6 +15732,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.29",
@@ -34956,6 +34964,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw=="
+    },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.29",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "aws-amplify": "^5.3.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sonner": "^1.2.4"
+    "sonner": "^1.2.4",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",
@@ -26,6 +27,7 @@
     "@types/node": "^20.8.8",
     "@types/react": "^18.2.32",
     "@types/react-dom": "^18.2.14",
+    "@types/uuid": "^9.0.8",
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "@vitest/ui": "^0.34.6",
     "jsdom": "^22.1.0",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -10,13 +10,13 @@ import { useAppContext } from "context/AppContext";
 
 const Editor = () => {
   const { state } = useAppContext();
-  const { screen } = state;
+  const { screen, screenId } = state;
 
   return (
     <div>
       <Header />
       <main>
-        {screen === "Collection" && <Collection />}
+        {screen === "Collection" && <Collection key={screenId} />}
         {screen === "Manifest" && <Manifest />}
         <Toaster toastOptions={toastOptions} />
       </main>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -105,7 +105,7 @@ const Header = () => {
               <DropdownMenu.Label style={{ fontSize: "0.7em" }}>
                 Logged in as {user.username}
               </DropdownMenu.Label>
-              <DropdownMenu.Item color="crimson" onClick={signOut}>
+              <DropdownMenu.Item color="ruby" onClick={signOut}>
                 Logout
               </DropdownMenu.Item>
             </DropdownMenu.Content>

--- a/src/components/Layouts/Collection.tsx
+++ b/src/components/Layouts/Collection.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Em,
+  Flex,
   Section,
   TableBody,
   TableColumnHeaderCell,
@@ -48,10 +49,13 @@ const Collection = () => {
               <TableColumnHeaderCell>Label</TableColumnHeaderCell>
               <TableColumnHeaderCell>Provider</TableColumnHeaderCell>
               <TableColumnHeaderCell>Status</TableColumnHeaderCell>
+              <TableColumnHeaderCell>
+                <span style={{ visibility: "hidden" }}>Actions</span>
+              </TableColumnHeaderCell>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {manifests.map((item) => (
+            {manifests?.map((item) => (
               <UITableCollectionItemsRow item={item} key={item.uri} />
             ))}
           </TableBody>

--- a/src/components/UI/AddManifest.tsx
+++ b/src/components/UI/AddManifest.tsx
@@ -1,3 +1,4 @@
+import { ActionTypes, useAppContext } from "context/AppContext";
 import {
   Button,
   Dialog,
@@ -15,11 +16,11 @@ import getApiResponse from "lib/getApiResponse";
 import { projectTitle } from "data";
 import { toast } from "sonner";
 import { toastDefaults } from "lib/vendor/sonner";
-import { useAppContext } from "context/AppContext";
+import { v4 as uuidv4 } from "uuid";
 
 const Required = () => {
   return (
-    <Strong color="crimson" style={{ color: "var(--crimson-9)" }}>
+    <Strong color="ruby" style={{ color: "var(--ruby-9)" }}>
       *
     </Strong>
   );
@@ -29,7 +30,7 @@ const UIAddManifest = () => {
   const [provider, setProvider] = useState<string>();
   const [uri, setUri] = useState<string>();
 
-  const { state } = useAppContext();
+  const { dispatch, state } = useAppContext();
   const { authToken } = state;
 
   const handleAddManifest = async () => {
@@ -64,9 +65,16 @@ const UIAddManifest = () => {
 
         if (response?.uri) {
           toast.dismiss();
-          toast.success(`Success`, {
-            description: `Manifest added successfully.`,
+          toast.success(`Added Manifest`, {
+            description: label,
             ...toastDefaults,
+          });
+
+          dispatch({ type: ActionTypes.SET_SCREEN, payload: "Collection" });
+          dispatch({ type: ActionTypes.SET_SCREEN_ID, payload: uuidv4() });
+          dispatch({
+            type: ActionTypes.SET_ACTIVE_MANIFEST,
+            payload: undefined,
           });
         }
       }

--- a/src/components/UI/DeleteManifest.tsx
+++ b/src/components/UI/DeleteManifest.tsx
@@ -1,0 +1,130 @@
+import { ActionTypes, useAppContext } from "context/AppContext";
+import {
+  Badge,
+  Button,
+  Callout,
+  Checkbox,
+  Dialog,
+  Flex,
+  Strong,
+  Text,
+} from "@radix-ui/themes";
+
+import { Cross2Icon } from "@radix-ui/react-icons";
+import React from "react";
+import getApiResponse from "lib/getApiResponse";
+import { toast } from "sonner";
+import { toastDefaults } from "lib/vendor/sonner";
+import { v4 as uuidv4 } from "uuid";
+
+const UIDeleteManifest = ({
+  disabled,
+  label,
+  uri,
+}: {
+  disabled: boolean;
+  label: string;
+  uri: string;
+}) => {
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+  const { state, dispatch } = useAppContext();
+  const { authToken } = state;
+
+  const handleDeleteManifest = async () => {
+    try {
+      const response = await getApiResponse({
+        route: "/metadata",
+        options: {
+          method: "DELETE",
+          body: JSON.stringify({
+            sortKey: "METADATA",
+            uri,
+          }),
+          headers: { Authorization: `Bearer ${authToken}` },
+        },
+      });
+
+      if (response?.uri) {
+        toast.dismiss();
+        toast.success(`Deleted Manifest`, {
+          description: label,
+          icon: <Cross2Icon />,
+          ...toastDefaults,
+        });
+
+        dispatch({ type: ActionTypes.SET_SCREEN, payload: "Collection" });
+        dispatch({ type: ActionTypes.SET_SCREEN_ID, payload: uuidv4() });
+        dispatch({ type: ActionTypes.SET_ACTIVE_MANIFEST, payload: undefined });
+      }
+    } catch (error) {
+      toast.dismiss();
+      toast.error(`Error`, {
+        description: `${error}`,
+        ...toastDefaults,
+      });
+      return;
+    }
+  };
+
+  return (
+    <Dialog.Root onOpenChange={() => setConfirmDelete(false)}>
+      <Dialog.Trigger>
+        <Button
+          color="ruby"
+          variant="soft"
+          disabled={disabled}
+          aria-disabled={disabled}
+          title={disabled ? "Public Manifests cannot be deleted." : ""}
+        >
+          Delete
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content style={{ maxWidth: 450 }}>
+        <Dialog.Title>Delete Manifest</Dialog.Title>
+        <Dialog.Description size="3" mb="5" weight="light"></Dialog.Description>
+
+        <Flex direction="column" gap="4">
+          <Callout.Root color="ruby">
+            <Callout.Icon>
+              <Cross2Icon />
+            </Callout.Icon>
+            <Callout.Text>
+              <Strong>{label}</Strong>
+            </Callout.Text>
+          </Callout.Root>
+          <Text size="3" weight="light">
+            Are you sure you want to permanently delete this Manifest? This
+            action cannot be undone.
+          </Text>
+          <Text as="label" size="3" weight="light">
+            <Flex gap="2">
+              <Checkbox
+                onCheckedChange={() => setConfirmDelete(!confirmDelete)}
+              />
+              <Strong>Yes, delete this Manifest</Strong>
+            </Flex>
+          </Text>
+        </Flex>
+
+        <Flex gap="3" mt="7" justify="end">
+          <Dialog.Close>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </Dialog.Close>
+          <Dialog.Close>
+            <Button
+              color="ruby"
+              onClick={handleDeleteManifest}
+              disabled={!confirmDelete}
+            >
+              Delete
+            </Button>
+          </Dialog.Close>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default UIDeleteManifest;

--- a/src/components/UI/Manifest/Header.tsx
+++ b/src/components/UI/Manifest/Header.tsx
@@ -1,6 +1,7 @@
-import { Flex, Heading, Switch, Text } from "@radix-ui/themes";
+import { Box, Flex, Heading, Switch, Text } from "@radix-ui/themes";
 import React, { useEffect, useState } from "react";
 
+import DeleteManifest from "components/UI/DeleteManifest";
 import { ManifestEditorManifest } from "types/manifest-editor";
 import getApiResponse from "lib/getApiResponse";
 import { useAppContext } from "context/AppContext";
@@ -54,13 +55,22 @@ const ManifestHeader = ({ activeManifest }: { activeManifest: string }) => {
         <Text size="2">({metadata.provider})</Text>
       </Flex>
       <Text as="label" size="2">
-        <Flex gap="2">
-          <Switch
-            size="3"
-            defaultChecked={metadata?.publicStatus}
-            onCheckedChange={handlePublicChange}
+        <Flex gap="5" align="center">
+          <Box>
+            <Flex gap="2">
+              <Switch
+                size="3"
+                defaultChecked={metadata?.publicStatus}
+                onCheckedChange={handlePublicChange}
+              />
+              Public?
+            </Flex>
+          </Box>
+          <DeleteManifest
+            disabled={metadata?.publicStatus}
+            label={metadata.label}
+            uri={metadata.uri}
           />
-          Public?
         </Flex>
       </Text>
     </Flex>

--- a/src/components/UI/Table/CollectionItemsRow.tsx
+++ b/src/components/UI/Table/CollectionItemsRow.tsx
@@ -2,6 +2,7 @@ import { ActionTypes, useAppContext } from "context/AppContext";
 import {
   Badge,
   Box,
+  Button,
   Flex,
   Link,
   TableCell,
@@ -11,6 +12,7 @@ import {
 } from "@radix-ui/themes";
 import React, { MouseEventHandler } from "react";
 
+import DeleteManifest from "components/UI/DeleteManifest";
 import { ManifestEditorManifest } from "types/manifest-editor";
 
 interface UITableRowProps {
@@ -20,7 +22,9 @@ interface UITableRowProps {
 const UITableRow: React.FC<UITableRowProps> = ({ item }) => {
   const { dispatch } = useAppContext();
 
-  const handleManifestClick: MouseEventHandler<HTMLAnchorElement> = () => {
+  const handleManifestClick: MouseEventHandler<
+    HTMLAnchorElement | HTMLButtonElement
+  > = () => {
     dispatch({ type: ActionTypes.SET_SCREEN, payload: "Manifest" });
     dispatch({ type: ActionTypes.SET_ACTIVE_MANIFEST, payload: item.uri });
   };
@@ -39,10 +43,22 @@ const UITableRow: React.FC<UITableRowProps> = ({ item }) => {
       <TableCell>{item.provider}</TableCell>
       <TableCell>
         {item.publicStatus ? (
-          <Badge>Public</Badge>
+          <Badge variant="outline">Public</Badge>
         ) : (
-          <Badge color="crimson">Private</Badge>
+          <Badge variant="outline" color="gray">
+            Private
+          </Badge>
         )}
+      </TableCell>
+      <TableCell>
+        <Flex justify="end" gap="3">
+          <Button onClick={handleManifestClick}>View</Button>
+          <DeleteManifest
+            disabled={item.publicStatus}
+            label={item.label}
+            uri={item.uri}
+          />
+        </Flex>
       </TableCell>
     </TableRow>
   );

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,37 +1,43 @@
 import React, { ReactNode, createContext, useContext, useReducer } from "react";
 
 import { useAuthenticator } from "@aws-amplify/ui-react";
+import { v4 as uuidv4 } from "uuid";
 
 interface AppState {
-  screen: "Collection" | "Manifest" | "Canvas";
   activeCanvas?: string;
   activeManifest?: string;
   authToken?: string;
   collection?: string;
+  screen: "Collection" | "Manifest" | "Canvas";
+  screenId?: string;
 }
 
 enum ActionTypes {
-  SET_SCREEN = "SET_SCREEN",
   SET_ACTIVE_CANVAS = "SET_ACTIVE_CANVAS",
   SET_ACTIVE_MANIFEST = "SET_ACTIVE_MANIFEST",
+  SET_SCREEN_ID = "SET_SCREEN_ID",
+  SET_SCREEN = "SET_SCREEN",
 }
 
 type AppAction =
-  | { type: ActionTypes.SET_SCREEN; payload: AppState["screen"] }
   | { type: ActionTypes.SET_ACTIVE_CANVAS; payload: AppState["activeCanvas"] }
   | {
       type: ActionTypes.SET_ACTIVE_MANIFEST;
       payload: AppState["activeManifest"];
-    };
+    }
+  | { type: ActionTypes.SET_SCREEN; payload: AppState["screen"] }
+  | { type: ActionTypes.SET_SCREEN_ID; payload: AppState["screenId"] };
 
 const appReducer = (state: AppState, action: AppAction): AppState => {
   switch (action.type) {
-    case ActionTypes.SET_SCREEN:
-      return { ...state, screen: action.payload };
     case ActionTypes.SET_ACTIVE_CANVAS:
       return { ...state, activeCanvas: action.payload };
     case ActionTypes.SET_ACTIVE_MANIFEST:
       return { ...state, activeManifest: action.payload };
+    case ActionTypes.SET_SCREEN:
+      return { ...state, screen: action.payload };
+    case ActionTypes.SET_SCREEN_ID:
+      return { ...state, screenId: action.payload };
     default:
       return state;
   }
@@ -66,6 +72,7 @@ const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
    * get the authToken from the useAuthenticator() hook
    */
   const { user } = useAuthenticator();
+  // @ts-ignore
   const authToken = user?.signInUserSession.idToken.jwtToken;
 
   /**
@@ -76,7 +83,10 @@ const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
 
   return (
     <AppContext.Provider
-      value={{ state: { ...state, authToken, collection }, dispatch }}
+      value={{
+        state: { ...state, authToken, collection, screenId: uuidv4() },
+        dispatch,
+      }}
     >
       {children}
     </AppContext.Provider>

--- a/src/lib/vendor/sonner.ts
+++ b/src/lib/vendor/sonner.ts
@@ -13,6 +13,6 @@ export const toastOptions = {
 };
 
 export const toastDefaults: ExternalToast = {
-  duration: 7000,
+  duration: 5000,
   position: "bottom-left",
 };

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -28,6 +28,7 @@ button.addManifest:hover {
 
 .toastCallout {
   min-width: 400px;
+  background-color: var(--accent-3) !important;
 }
 
 .toastCallout svg {
@@ -35,6 +36,6 @@ button.addManifest:hover {
 }
 
 .toastError {
-  background-color: var(--crimson-3);
-  color: var(--crimson-11);
+  background-color: var(--ruby-3) !important;
+  color: var(--ruby-11);
 }


### PR DESCRIPTION
This adds a **Delete** dialog for Manifests in two locations in the UI. In the main collection view, each line item will have a Delete button next to a View button. The delete button will also be visible on each Manifest screen.

A few things:

- Delete button is enabled if the public status of the manifest is false
- Clicking the button shows a dialog with a the manifest Label, asking for confirmation with a checkbox, a cancel button, and the final delete button
- Deleting sends an API request to remove the item from DynamoDB
- On API response, a toast message is delivered to user, and the page is refreshed to the main collection listing showing a table of all current manifests

![image](https://github.com/nulib/manifest-edit-ui/assets/7376450/f5b85c7f-a1b3-4303-acd6-7d2a24efe958)

![image](https://github.com/nulib/manifest-edit-ui/assets/7376450/dab45617-b295-4f0f-9ec9-07474f5a6656)