### PR TITLE
Add user group conditional for publish button.

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import React, { MouseEventHandler } from "react";
 import { CaretDownIcon } from "@radix-ui/react-icons";
 import UIAddManifest from "components/UI/AddManifest";
 import getApiResponse from "lib/getApiResponse";
+import { isAdminUser } from "lib/getUser";
 import { projectTitle } from "data";
 import { toast } from "sonner";
 import { toastDefaults } from "lib/vendor/sonner";
@@ -14,6 +15,8 @@ const Header = () => {
   const { user, signOut } = useAuthenticator();
   const { state, dispatch } = useAppContext();
   const { authToken, collection } = state;
+
+  const adminUser = isAdminUser(user);
 
   const handleViewCollection: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch({ type: ActionTypes.SET_SCREEN, payload: "Collection" });
@@ -98,9 +101,11 @@ const Header = () => {
                   </DropdownMenu.Item>
                 </DropdownMenu.SubContent>
               </DropdownMenu.Sub>
-              <DropdownMenu.Item onClick={handlePublish}>
-                Publish Collection
-              </DropdownMenu.Item>
+              {adminUser && (
+                <DropdownMenu.Item onClick={handlePublish}>
+                  Publish Collection
+                </DropdownMenu.Item>
+              )}
               <DropdownMenu.Separator />
               <DropdownMenu.Label style={{ fontSize: "0.7em" }}>
                 Logged in as {user.username}

--- a/src/lib/getUser.ts
+++ b/src/lib/getUser.ts
@@ -1,0 +1,7 @@
+const isAdminUser = (user: User) => {
+  const groups =
+    user?.signInUserSession?.accessToken?.payload["cognito:groups"];
+  return groups?.includes("Admin");
+};
+
+export { isAdminUser };


### PR DESCRIPTION
This adds a small helper to peel that checks if the logged in user is within the `Admin` group in the Cognito user pool. If the `isAdminUser()` check is true, then the **Publish Collection** button will appear in the **Options** dropdown. 

- Test first by logging in and seeing that the Publish Collection button is not visible
- Add your user to the Admin group
- Refresh and/or logout and login again
- Test to see if the button is visible