### PR TITLE
Add note field.

### DIFF
--- a/src/components/Layouts/Manifest.tsx
+++ b/src/components/Layouts/Manifest.tsx
@@ -65,6 +65,7 @@ const Manifest = () => {
                 <TableColumnHeaderCell>Canvas</TableColumnHeaderCell>
                 <TableColumnHeaderCell>Translation</TableColumnHeaderCell>
                 <TableColumnHeaderCell>Transcription</TableColumnHeaderCell>
+                <TableColumnHeaderCell>Notes</TableColumnHeaderCell>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/src/components/UI/Table/AnnotationCell.tsx
+++ b/src/components/UI/Table/AnnotationCell.tsx
@@ -25,7 +25,7 @@ const UITableAnnotationCell: React.FC<AnnotationCellProps> = ({
 
   // creates sortKey, ex: TRANSCRIPTION#https://resource.uri/id/info.json
   const sortKey = `${motivation.toUpperCase()}#${resourceId}`;
-  const dir = motivation === "translation" ? "ltr" : "rtl";
+  const dir = ["translation", "note"].includes(motivation) ? "ltr" : "rtl";
 
   useEffect(() => {
     (async () => {

--- a/src/components/UI/Table/ManifestItemsRow.tsx
+++ b/src/components/UI/Table/ManifestItemsRow.tsx
@@ -78,6 +78,13 @@ const UITableCanvasRow: React.FC<UITableRowProps> = ({
           resourceId={resourceId}
         />
       </TableCell>
+      <TableCell>
+        <AnnotationCell
+          manifestId={manifestId}
+          motivation="note"
+          resourceId={resourceId}
+        />
+      </TableCell>
     </TableRow>
   );
 };

--- a/src/components/UI/Table/Table.tsx
+++ b/src/components/UI/Table/Table.tsx
@@ -1,12 +1,5 @@
-import {
-  TableBody,
-  TableColumnHeaderCell,
-  TableHeader,
-  TableRoot,
-  TableRow,
-} from "@radix-ui/themes";
-
 import React from "react";
+import { TableRoot } from "@radix-ui/themes";
 
 const UITable = ({ children }: { children: React.ReactNode[] }) => {
   return <TableRoot variant="surface">{children}</TableRoot>;


### PR DESCRIPTION
## What does this do?

This adds a Note field to the table representing each canvas of a Manifest. The user can now add a note for respective rows. The notes are stored in DynamoDB with the **sortKey** matching a pattern `NOTE#{canvas-id}` and otherwise match the data model of transcriptions and translations.

Example:

```
NOTE#https://iiif.dc.library.northwestern.edu/iiif/2/ffc79bc0-474b-4db1-897c-646cf8efd930
```

Notes are NOT included in the publish IIIF Manifest as annotations.