### PR TITLE
Update dialog Content-Type.

### DIFF
--- a/src/components/UI/Dialog.tsx
+++ b/src/components/UI/Dialog.tsx
@@ -50,7 +50,7 @@ const UIDialog = ({
         }),
         headers: {
           Authorization: `Bearer ${authToken}`,
-          // "Content-Type": "application/json",
+          "Content-Type": "application/json",
         },
       },
     });


### PR DESCRIPTION
This updates the `Content-Type` to `application/json` for transcription and translation dialog submissions. This aligns with https://github.com/nulib/manifest-edit-backend/pull/7.