### PR TITLE
Add label and summary edit component to Manifest screen.

### DIFF
--- a/src/components/Layouts/Manifest.tsx
+++ b/src/components/Layouts/Manifest.tsx
@@ -50,7 +50,7 @@ const Manifest = () => {
       {manifest && (
         <Section size="1" pr="5" pl="5">
           <Box pb="4">
-            <ManifestHeader activeManifest={activeManifest as string} />
+            <ManifestHeader manifest={manifest} />
           </Box>
           <UITable>
             <Table.Header>

--- a/src/components/UI/EditString.test.tsx
+++ b/src/components/UI/EditString.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import EditString from "./EditString";
+import { ManifestEditorManifest } from "types/manifest-editor";
+import React from "react";
+
+const metadata: ManifestEditorManifest = {
+  label: "My Label",
+  summary: "summary",
+  provider: "provider",
+  publicStatus: false,
+  sortKey: "sortKey",
+  uri: "uri",
+};
+
+describe("EditString", () => {
+  it("should render the EditString component", () => {
+    // Capture the initial value of the label
+    let label = metadata.label;
+
+    function mockHandleSave(metadata: ManifestEditorManifest) {
+      label = metadata.label;
+    }
+
+    render(
+      <EditString
+        attribute="label"
+        metadata={metadata}
+        onSave={mockHandleSave}
+      />
+    );
+    expect(screen.getByTestId("ui-edit-string")).toBeInTheDocument();
+    expect(screen.getByText("My Label")).toBeInTheDocument();
+
+    // Clicking the Edit button should show the input field
+    fireEvent.click(screen.getByText("Edit"));
+
+    const input = screen.getByRole("textbox");
+    const save = screen.getByText("Save");
+    expect(input).toBeInTheDocument();
+
+    expect(input).toHaveValue("My Label");
+    expect(save).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+
+    // Changing the value of the input field
+    fireEvent.change(input, { target: { value: "New Label" } });
+    expect(input).toHaveValue("New Label");
+
+    // Clicking the Save button should save the new value
+    fireEvent.click(save);
+    expect(label).toBe("New Label");
+  });
+});

--- a/src/components/UI/EditString.tsx
+++ b/src/components/UI/EditString.tsx
@@ -1,0 +1,77 @@
+import { Flex, Link, Text, TextField, TextProps } from "@radix-ui/themes";
+import { useRef, useState } from "react";
+
+import { InternationalString } from "@iiif/presentation-3";
+import { ManifestEditorManifest } from "types/manifest-editor";
+import { getLabelAsString } from "lib/iiif-helpers";
+
+const UIEditString = ({
+  attribute,
+  metadata,
+  onSave,
+  originalValue,
+  textProps,
+}: {
+  attribute: "label" | "summary" | "provider";
+  metadata: ManifestEditorManifest;
+  onSave: (metadata: ManifestEditorManifest) => void;
+  originalValue?: InternationalString;
+  textProps?: TextProps;
+}) => {
+  const value = metadata[attribute]
+    ? metadata[attribute]
+    : getLabelAsString(originalValue);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleIsEditing = () => {
+    setIsEditing(true);
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+  };
+
+  const handleCancel = () => {
+    setInputValue(value);
+    setIsEditing(false);
+  };
+
+  const handleSave = () => {
+    setIsEditing(false);
+    onSave({ ...metadata, [attribute]: inputValue });
+  };
+
+  return (
+    <Flex align="center" gap="2" width="100%" data-testid="ui-edit-string">
+      {isEditing ? (
+        <>
+          <TextField.Root
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            ref={inputRef}
+            style={{ flexGrow: 1 }}
+          ></TextField.Root>
+          <Link href="#" onClick={handleSave} size="1">
+            Save
+          </Link>
+          <Link href="#" color="crimson" onClick={handleCancel} size="1">
+            Cancel
+          </Link>
+        </>
+      ) : (
+        <>
+          <Text {...textProps} color={!value ? "gray" : undefined}>
+            {value ? value : "None"}
+          </Text>
+          <Link href="#" onClick={handleIsEditing} size="1">
+            Edit
+          </Link>
+        </>
+      )}
+    </Flex>
+  );
+};
+
+export default UIEditString;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,7 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { afterEach, expect } from "vitest";
-
+import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
 // runs a cleanup after each test case (e.g. clearing jsdom)

--- a/src/types/manifest-editor.ts
+++ b/src/types/manifest-editor.ts
@@ -1,6 +1,7 @@
 interface ManifestEditorManifest {
   uri: string;
   label: string;
+  summary: string;
   provider: string;
   publicStatus: boolean;
   sortKey?: string;


### PR DESCRIPTION
## What does this do?

This work adds adds a UIEditString component allowing front end users to modify the value of `label` and `summary` for respective Manifests. Editing will render an `input` that allows the user to "Save" or "Cancel". The Save method will then PUT the updated value to DynamoDB replacing any original value. The new saved value(s) will then be sent back down to the UIEditString and render again as a text string.

Additionally, it adds fallback support that allows renders an original value from the source Manifest if the attribute is not set in DynamoDB. This is necessary as many items will not have `summary` until further edits are made.

![image](https://github.com/user-attachments/assets/4348e80d-76a0-48ba-b4fb-a0e9c8676ced)